### PR TITLE
Changed calculation of filter_threshold so thresholds >100 don't error 

### DIFF
--- a/pytranscoder/utils.py
+++ b/pytranscoder/utils.py
@@ -14,8 +14,8 @@ def filter_threshold(profile: Profile, inpath, outpath):
         pct_threshold = profile.threshold
         orig_size = os.path.getsize(inpath)
         new_size = os.path.getsize(outpath)
-        pct_savings = 100 - math.floor((new_size * 100) / orig_size)
-        if pct_savings < pct_threshold:
+        size_threshold = pct_threshold * orig_size
+        if new_size > size_threshold:
             return False
         return True
 


### PR DESCRIPTION
Since it's not always necessary that resulting transcode have a smaller size, changed the way this function works so you can set threshold higher than 100%. Previously, putting something like 150% would result in early termination of the transcode because it required the new file to be smaller than the old file.