### PR TITLE
Duration should first be cast to float before int

### DIFF
--- a/pytranscoder/media.py
+++ b/pytranscoder/media.py
@@ -225,7 +225,7 @@ class MediaInfo:
                 minfo['fps'] = str(fr)
                 minfo['colorspace'] = stream['pix_fmt']
                 if 'duration' in stream:
-                    minfo['runtime'] = int(stream['duration'])
+                    minfo['runtime'] = int(float(stream['duration']))
                 else:
                     if 'tags' in stream:
                         for name, value in stream['tags'].items():


### PR DESCRIPTION
Floating point numbers in json are quoted literal strings. Python chokes on a direct cast to int when the string value passed in contains a decimal.