### PR TITLE
more graceful non-UTF8 ffmpeg output handling

### DIFF
--- a/pytranscoder/ffmpeg.py
+++ b/pytranscoder/ffmpeg.py
@@ -33,7 +33,7 @@ class FFmpeg:
         :return:        Instance of MediaInfo
         """
         with subprocess.Popen([self.ffmpeg, '-i', _path], stderr=subprocess.PIPE) as proc:
-            output = proc.stderr.read().decode(encoding='utf8')
+            output = proc.stderr.read().decode(encoding='utf8', errors='replace')
             mi = MediaInfo.parse_details(_path, output)
             if mi.valid:
                 return mi
@@ -51,7 +51,7 @@ class FFmpeg:
 
         args = [ffprobe_path, '-v', '1', '-show_streams', '-print_format', 'json', '-i', _path]
         with subprocess.Popen(args, stdout=subprocess.PIPE) as proc:
-            output = proc.stdout.read().decode(encoding='utf8')
+            output = proc.stdout.read().decode(encoding='utf8', errors='replace')
             info = json.loads(output)
             return MediaInfo.parse_details_json(_path, info)
 
@@ -97,6 +97,7 @@ class FFmpeg:
                               stdout=subprocess.PIPE,
                               stderr=subprocess.STDOUT,
                               universal_newlines=True,
+                              errors='replace',
                               shell=False) as p:
 
             for stats in self.monitor_ffmpeg(p):
@@ -114,6 +115,7 @@ class FFmpeg:
                               stdout=subprocess.PIPE,
                               stderr=subprocess.STDOUT,
                               universal_newlines=True,
+                              errors='replace',
                               shell=False) as p:
             for stats in self.monitor_ffmpeg(p):
                 if event_callback is not None:


### PR DESCRIPTION
If the output of ffmpeg -- which operates on bytes -- contains invalid UTF-8 sequences pytranscoder currently fails with a `UnicodeDecodeError`.

This change sets `errors='replace'` for all ffmpeg subprocesses.  This will cause the invalid byte to be replaced with the unicode "replacement character", the designated placeholder for this sort of thing.

That'll theoretically "corrupt" the output, but in practice it won't break anything in a way that matters, and is much simpler (and smarter) than trying to work with the data as raw bytes, or an 8-bit encoding.