### PR TITLE
handle invalid UTF-8 more cleanly - replacement character

### DIFF
--- a/pytranscoder/ffmpeg.py
+++ b/pytranscoder/ffmpeg.py
@@ -35,7 +35,7 @@ class FFmpeg(Processor):
         :return:        Instance of MediaInfo
         """
         with subprocess.Popen([self.path, '-i', _path], stderr=subprocess.PIPE) as proc:
-            output = proc.stderr.read().decode(encoding='utf8')
+            output = proc.stderr.read().decode(encoding='utf8', errors='replace')
             mi = MediaInfo.parse_ffmpeg_details(_path, output)
             if mi.valid:
                 return mi
@@ -53,7 +53,7 @@ class FFmpeg(Processor):
 
         args = [ffprobe_path, '-v', '1', '-show_streams', '-print_format', 'json', '-i', _path]
         with subprocess.Popen(args, stdout=subprocess.PIPE) as proc:
-            output = proc.stdout.read().decode(encoding='utf8')
+            output = proc.stdout.read().decode(encoding='utf8', errors='replace')
             info = json.loads(output)
             return MediaInfo.parse_ffmpeg_details_json(_path, info)
 

--- a/pytranscoder/handbrake.py
+++ b/pytranscoder/handbrake.py
@@ -34,7 +34,7 @@ class Handbrake(Processor):
         :return:        Instance of MediaInfo
         """
         with subprocess.Popen([self.path, '--scan', '-i', _path], stderr=subprocess.PIPE) as proc:
-            output = proc.stderr.read().decode(encoding='utf8')
+            output = proc.stderr.read().decode(encoding='utf8', errors='replace')
             mi = MediaInfo.parse_handbrake_details(_path, output)
             if mi.valid:
                 return mi

--- a/pytranscoder/utils.py
+++ b/pytranscoder/utils.py
@@ -60,7 +60,7 @@ def calculate_progress(info: MediaInfo, stats: Dict) -> (int, int):
 
 def run(cmd):
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False)
-    output = p.communicate()[0].decode('utf-8')
+    output = p.communicate()[0].decode('utf-8', errors='replace')
     return p.returncode, output
 
 


### PR DESCRIPTION
This updates the UTF-8 decoding in pytranscoder to treat non-UTF-8
output without error: it replaces invalid characters with the Unicode
`REPLACEMENT CHARACTER` `U+FFFD`.

These characters only occur in "user"-supplied metadata in media, such
as title, series, or encoder tags, so there is little to no risk of loss
of any useful information in the change.